### PR TITLE
Add wheel number overlay and tighten ball orbit

### DIFF
--- a/Roulette.wpf/Views/RouletteWindow.xaml
+++ b/Roulette.wpf/Views/RouletteWindow.xaml
@@ -3,6 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
     xmlns:viewModels="clr-namespace:Roulette.Wpf.ViewModels"
+    xmlns:views="clr-namespace:Roulette.Wpf.Views"
     xmlns:conv="clr-namespace:Roulette.Wpf.Converters"
     Title="Roulette" Width="1180" Height="820" WindowStartupLocation="CenterScreen">
 
@@ -261,36 +262,75 @@
             <!-- ===== RIGHT: WHEEL (animated) ===== -->
             <Border Style="{StaticResource Card}">
                 <Grid>
-                    <!-- Wheel image with a named RotateTransform we animate -->
-                    <Grid>
-                        <Image
-                         Source="/Roulette.Wpf;component/Assets/wheel.png"
-                         Stretch="Uniform"
-                         RenderOptions.BitmapScalingMode="HighQuality"
-                         HorizontalAlignment="Center"
-                         VerticalAlignment="Center"
-                         Width="360" Height="360">
+                    <Grid Width="360" Height="360" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <!-- Wheel image with a named RotateTransform we animate -->
+                        <Image Source="/Roulette.Wpf;component/Assets/wheel.png"
+                               Stretch="Uniform"
+                               RenderOptions.BitmapScalingMode="HighQuality"
+                               RenderTransformOrigin="0.5,0.5">
                             <Image.RenderTransform>
-                                <RotateTransform x:Name="WheelRotate" Angle="0" CenterX="180" CenterY="180"/>
+                                <RotateTransform x:Name="WheelRotate" Angle="0"/>
                             </Image.RenderTransform>
                         </Image>
 
+                        <!-- Number ring overlay -->
+                        <ItemsControl ItemsSource="{x:Static views:RouletteWindow.WheelLabels}"
+                                      IsHitTestVisible="False"
+                                      Panel.ZIndex="2">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <Canvas Width="360" Height="360"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemContainerStyle>
+                                <Style TargetType="ContentPresenter">
+                                    <Setter Property="Canvas.Left" Value="{Binding Left}"/>
+                                    <Setter Property="Canvas.Top" Value="{Binding Top}"/>
+                                </Style>
+                            </ItemsControl.ItemContainerStyle>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid Width="34" Height="34" RenderTransformOrigin="0.5,0.5">
+                                        <Grid.RenderTransform>
+                                            <RotateTransform Angle="{Binding Angle}"/>
+                                        </Grid.RenderTransform>
+                                        <Border Width="34" Height="34" CornerRadius="17"
+                                                Background="{Binding Background}"
+                                                BorderBrush="White" BorderThickness="2"
+                                                RenderTransformOrigin="0.5,0.5">
+                                            <TextBlock Text="{Binding Number}" FontSize="14" FontWeight="Bold" Foreground="White"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                       RenderTransformOrigin="0.5,0.5">
+                                                <TextBlock.RenderTransform>
+                                                    <RotateTransform Angle="{Binding TextAngle}"/>
+                                                </TextBlock.RenderTransform>
+                                            </TextBlock>
+                                        </Border>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
                         <!-- Ball orbiting the wheel (perfect circle around the center) -->
-                        <Ellipse x:Name="Ball"
-         Width="12" Height="12"
-         Fill="White" Stroke="#999" StrokeThickness="1"
-         HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,22,0,0">
-                            <Ellipse.Effect>
-                                <DropShadowEffect BlurRadius="6" ShadowDepth="0" Color="#66000000"/>
-                            </Ellipse.Effect>
-                            <Ellipse.RenderTransform>
-                                <!-- CenterX/CenterY must match half the wheel size (180 for 360px wheel) -->
-                                <RotateTransform x:Name="BallRotate" Angle="0" CenterX="180" CenterY="180"/>
-                            </Ellipse.RenderTransform>
-                        </Ellipse>
+                        <Grid Width="360" Height="360" RenderTransformOrigin="0.5,0.5" Panel.ZIndex="3">
+                            <Grid.Clip>
+                                <EllipseGeometry Center="180,180" RadiusX="170" RadiusY="170"/>
+                            </Grid.Clip>
+                            <Grid.RenderTransform>
+                                <RotateTransform x:Name="BallRotate" Angle="0"/>
+                            </Grid.RenderTransform>
+                            <Ellipse x:Name="Ball"
+                                     Width="14" Height="14"
+                                     Fill="White" Stroke="#999" StrokeThickness="1"
+                                     HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,36,0,0">
+                                <Ellipse.Effect>
+                                    <DropShadowEffect BlurRadius="6" ShadowDepth="0" Color="#66000000"/>
+                                </Ellipse.Effect>
+                            </Ellipse>
+                        </Grid>
 
                         <!-- Fixed marker at the top (ball “window”) -->
-                        <Grid HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,6,0,0">
+                        <Grid HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,6,0,0" Panel.ZIndex="4">
                             <Polygon Points="0,0 12,0 6,10" Fill="White" Stroke="#444" StrokeThickness="1"/>
                         </Grid>
 

--- a/Roulette.wpf/Views/RouletteWindow.xaml.cs
+++ b/Roulette.wpf/Views/RouletteWindow.xaml.cs
@@ -1,41 +1,49 @@
-﻿using MahApps.Metro.Controls;
+using MahApps.Metro.Controls;
+using RouletteCore = Roulette.Core;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Media;
 using System.Windows;
 using System.Windows.Media;
-using System.Windows.Media.Animation;
 using System.Windows.Threading;
 
 namespace Roulette.Wpf.Views
 {
     public partial class RouletteWindow : MetroWindow
     {
-        // ----- Wheel / ball parameters -----
-        private const double SPIN_SECONDS = 8.0;      // total spin time
-        private const int WHEEL_REVS = 9;        // visual full turns (clockwise)
-        private const int BALL_REVS = 6;        // visual full turns CCW before settling
+        // ----- High-level timing/feel -----
+        private const double SPIN_DURATION_SECONDS = 9.25;    // total animation time
+        private const double WHEEL_EXTRA_REVOLUTIONS = 6.75;   // extra clockwise laps before landing
+        private const double BALL_RELATIVE_REVOLUTIONS = 11.5; // how far ahead the ball starts (counter-clockwise)
         private const double SECTOR_DEGREES = 360.0 / 37.0;
-        private const double OFFSET_DEGREES = 0.0;      // nudge if your PNG's "0" isn't at the marker
+        private const double OFFSET_DEGREES = 0.0;             // PNG alignment tweak if required
+        private const double WHEEL_CENTER = 180.0;             // half the rendered wheel diameter
+        private const double NUMBER_RING_RADIUS = 146.0;       // where we place the number pips around the wheel
+        private const double NUMBER_LABEL_SIZE = 34.0;
 
-        // European wheel order, clockwise from 0
+        // European wheel ordering, clockwise from 0 (at the marker)
         private static readonly int[] WheelOrder =
         {
             0,32,15,19,4,21,2,25,17,34,6,27,13,36,11,30,8,23,
             10,5,24,16,33,1,20,14,31,9,22,18,29,7,28,12,35,3,26
         };
 
-        // state
-        private double _startAngle;   // wheel angle at spin start
-        private double _endAngle;     // wheel angle at spin end
-        private double _currentAngle; // wheel angle we keep after spin
-        private DateTime _spinStart;
-        private bool _spinning;
+        private static readonly SolidColorBrush WheelRedBrush = CreateWheelBrush(177, 44, 44);
+        private static readonly SolidColorBrush WheelBlackBrush = CreateWheelBrush(34, 34, 34);
+        private static readonly SolidColorBrush WheelGreenBrush = CreateWheelBrush(14, 122, 58);
 
-        // VM + sounds
+        public static IReadOnlyList<WheelLabel> WheelLabels { get; } = BuildWheelLabels();
+
+        // View-model + sounds
         private ViewModels.GameViewModel? _vm;
         private SoundPlayer? _clickA, _clickB, _drop;
         private bool _useA = true;
+
+        // Spin state
+        private SpinAnimationPlan? _activeSpin;
+        private DateTime _spinStartUtc;
+        private double _currentWheelAngle; // persists between spins so consecutive spins feel continuous
         private DispatcherTimer? _tickTimer;
 
         public RouletteWindow()
@@ -64,102 +72,144 @@ namespace Roulette.Wpf.Views
             _vm = null;
         }
 
-        // ----- Spin orchestration (render loop) -----
+        // ----- Spin orchestration -----
         private void AnimateToNumber(int number)
         {
-            // compute target wheel angle so 'number' lands under the top marker
-            int idx = Array.IndexOf(WheelOrder, number);
-            if (idx < 0) idx = 0;
+            _activeSpin = BuildPlan(number);
+            _spinStartUtc = DateTime.UtcNow;
 
-            double targetAngleAtMarker = OFFSET_DEGREES + idx * SECTOR_DEGREES;
-
-            // align from our current angle to that target with several full clockwise turns
-            _startAngle = _currentAngle;
-            // how far clockwise from currentMod to target in [0,360)
-            double currentMod = Mod(_startAngle, 360.0);
-            double delta = targetAngleAtMarker - currentMod;
-            if (delta < 0) delta += 360.0;
-
-            _endAngle = _startAngle + WHEEL_REVS * 360.0 + delta;
-
-            // start timing
-            _spinStart = DateTime.UtcNow;
-            _spinning = true;
-
-            // start SFX ticking
             StartTickTimer();
 
-            // drive both wheel and ball with the same render tick
             CompositionTarget.Rendering -= OnRenderSpin;
             CompositionTarget.Rendering += OnRenderSpin;
         }
 
         private void OnRenderSpin(object? sender, EventArgs e)
         {
-            if (!_spinning) return;
+            if (_activeSpin is not SpinAnimationPlan plan) return;
 
-            double t = (DateTime.UtcNow - _spinStart).TotalSeconds;
-            double p = Math.Clamp(t / SPIN_SECONDS, 0.0, 1.0);
+            double elapsed = (DateTime.UtcNow - _spinStartUtc).TotalSeconds;
+            double duration = plan.DurationSeconds;
+            double rawProgress = Math.Clamp(elapsed / duration, 0.0, 1.0);
 
-            // Easing for the wheel (quintic ease out)
-            double ew = EaseOutQuint(p);
-            double wheelAngle = Lerp(_startAngle, _endAngle, ew);
+            // The wheel eases out over time (fast start, gentle stop).
+            double wheelProgress = EaseOutQuint(rawProgress);
+            double wheelAngle = Lerp(plan.WheelStartAngle, plan.WheelEndAngle, wheelProgress);
             WheelRotate.Angle = wheelAngle;
 
-            // Ball angle: start with BALL_REVS CCW turns, decelerate and land at marker (angle 0)
-            // Use a slightly different curve so the ball feels lighter (cubic ease out towards ~6s, then in)
-            // We'll combine two phases via one smooth curve: fast at start, gently to 0.
-            double eb = EaseOutCubic(p);            // decelerate early
-            double ballTurns = (1.0 - eb) * BALL_REVS;   // remaining turns to go
-            double ballAngle = -ballTurns * 360.0;       // negative = CCW from the top marker
+            // The ball starts far ahead (counter-rotating), gradually loses speed and syncs with the wheel.
+            double ballProgress = EaseInOutQuint(rawProgress);
+            double relativeAngle = Lerp(plan.BallRelativeStartAngle, plan.BallRelativeEndAngle, ballProgress);
+            double ballAngle = wheelAngle + relativeAngle;
             BallRotate.Angle = ballAngle;
 
-            // end of spin
-            if (p >= 1.0)
+            if (rawProgress >= 1.0)
             {
-                _spinning = false;
-                CompositionTarget.Rendering -= OnRenderSpin;
-
-                // lock final angles
-                _currentAngle = _endAngle;
-                WheelRotate.Angle = _currentAngle;
-                BallRotate.Angle = 0; // ball at the marker
-
-                StopTickTimer();
-                PlayDrop();
-                BallBounce();
-
-                // commit logical spin result/payout
-                _vm?.CommitPendingSpin();
+                FinishSpin(plan);
             }
         }
 
-        // Small visual bounce on "drop"
+        private void FinishSpin(SpinAnimationPlan plan)
+        {
+            CompositionTarget.Rendering -= OnRenderSpin;
+            StopTickTimer();
+
+            _currentWheelAngle = NormalizeDegrees(plan.WheelEndAngle);
+            WheelRotate.Angle = _currentWheelAngle;
+            BallRotate.Angle = 0; // ball rests at the marker
+
+            PlayDrop();
+            BallBounce();
+
+            _activeSpin = null;
+            _vm?.CommitPendingSpin();
+        }
+
+        private SpinAnimationPlan BuildPlan(int number)
+        {
+            double startWheel = _currentWheelAngle;
+
+            int index = Array.IndexOf(WheelOrder, number);
+            if (index < 0) index = 0;
+            double targetAngleAtMarker = OFFSET_DEGREES + index * SECTOR_DEGREES;
+
+            double currentMod = Mod(startWheel, 360.0);
+            double deltaToTarget = targetAngleAtMarker - currentMod;
+            if (deltaToTarget <= 0) deltaToTarget += 360.0;
+
+            double wheelEnd = startWheel + WHEEL_EXTRA_REVOLUTIONS * 360.0 + deltaToTarget;
+
+            // The ball is animated relative to the wheel.  It begins many laps ahead (counter-clockwise) and
+            // bleeds energy until it lines up with the marker exactly when the wheel reaches its final pose.
+            double relativeStart = -startWheel - BALL_RELATIVE_REVOLUTIONS * 360.0;
+            double relativeEnd = -wheelEnd;
+
+            return new SpinAnimationPlan(startWheel, wheelEnd, relativeStart, relativeEnd, SPIN_DURATION_SECONDS);
+        }
+
+        private static IReadOnlyList<WheelLabel> BuildWheelLabels()
+        {
+            var labels = new List<WheelLabel>(WheelOrder.Length);
+            double halfLabel = NUMBER_LABEL_SIZE / 2.0;
+
+            for (int i = 0; i < WheelOrder.Length; i++)
+            {
+                int number = WheelOrder[i];
+                double angle = OFFSET_DEGREES + i * SECTOR_DEGREES;
+                double radians = angle * Math.PI / 180.0;
+
+                double centerX = WHEEL_CENTER + Math.Sin(radians) * NUMBER_RING_RADIUS;
+                double centerY = WHEEL_CENTER - Math.Cos(radians) * NUMBER_RING_RADIUS;
+
+                Brush background = number == 0
+                    ? WheelGreenBrush
+                    : (RouletteCore.Wheel.GetColor(number) == RouletteCore.Color.Red ? WheelRedBrush : WheelBlackBrush);
+
+                labels.Add(new WheelLabel(number,
+                    centerX - halfLabel,
+                    centerY - halfLabel,
+                    angle,
+                    background));
+            }
+
+            return labels;
+        }
+
+        private static SolidColorBrush CreateWheelBrush(byte r, byte g, byte b)
+        {
+            var brush = new SolidColorBrush(System.Windows.Media.Color.FromRgb(r, g, b));
+            brush.Freeze();
+            return brush;
+        }
+
+        // Small bounce when the ball "drops" into the pocket.
         private void BallBounce()
         {
-            // A tiny scale/translate using a transient animation (doesn't affect the circular path during spin)
-            // We momentarily nudge the Ball element down and back up by adjusting Margin.Top.
             var start = Ball.Margin;
             var down = new Thickness(start.Left, start.Top + 3, start.Right, start.Bottom);
 
-            var a = new System.Windows.Media.Animation.ThicknessAnimation
+            var animation = new System.Windows.Media.Animation.ThicknessAnimation
             {
                 From = start,
                 To = down,
-                Duration = TimeSpan.FromMilliseconds(100),
+                Duration = TimeSpan.FromMilliseconds(110),
                 AutoReverse = true,
-                EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut }
+                EasingFunction = new System.Windows.Media.Animation.QuadraticEase
+                {
+                    EasingMode = System.Windows.Media.Animation.EasingMode.EaseOut
+                }
             };
-            Ball.BeginAnimation(MarginProperty, a);
+
+            Ball.BeginAnimation(MarginProperty, animation);
         }
 
-        // ----- Sounds -----
+        // ----- Sound ticking -----
         private void StartTickTimer()
         {
             _tickTimer?.Stop();
             _tickTimer = new DispatcherTimer(DispatcherPriority.Background)
             {
-                Interval = TimeSpan.FromMilliseconds(85) // fast at start
+                Interval = TimeSpan.FromMilliseconds(90)
             };
             _tickTimer.Tick += TickTimerOnTick;
             _tickTimer.Start();
@@ -175,24 +225,34 @@ namespace Roulette.Wpf.Views
 
         private void TickTimerOnTick(object? sender, EventArgs e)
         {
-            // slow the ticking as we approach the end
-            var elapsed = (DateTime.UtcNow - _spinStart).TotalSeconds;
-            double p = Math.Clamp(elapsed / SPIN_SECONDS, 0.0, 1.0);
+            if (_activeSpin is not SpinAnimationPlan plan)
+            {
+                StopTickTimer();
+                return;
+            }
 
-            // ease interval from ~85ms to ~220ms
-            double ms = 85 + 135 * p;
-            if (_tickTimer != null) _tickTimer.Interval = TimeSpan.FromMilliseconds(ms);
+            double elapsed = (DateTime.UtcNow - _spinStartUtc).TotalSeconds;
+            double progress = Math.Clamp(elapsed / plan.DurationSeconds, 0.0, 1.0);
+
+            // Ease the tick spacing so the impacts slow down as we approach the end of the spin.
+            double eased = EaseOutCubic(progress);
+            double intervalMs = 85 + eased * 150; // from ~85ms up to ~235ms
+            if (_tickTimer != null)
+            {
+                _tickTimer.Interval = TimeSpan.FromMilliseconds(intervalMs);
+            }
 
             PlayClick();
 
-            if (p >= 1.0) StopTickTimer();
+            if (progress >= 1.0)
+            {
+                StopTickTimer();
+            }
         }
 
+        // ----- Sounds -----
         private void TryLoadSounds()
         {
-            // Optional WAVs (Build Action: Resource):
-            //  /Roulette.Wpf;component/Assets/Sounds/click.wav
-            //  /Roulette.Wpf;component/Assets/Sounds/drop.wav
             try
             {
                 _clickA = LoadWav("pack://application:,,,/Roulette.Wpf;component/Assets/Sounds/click.wav");
@@ -201,7 +261,7 @@ namespace Roulette.Wpf.Views
             }
             catch
             {
-                _clickA = _clickB = _drop = null; // run silent if missing
+                _clickA = _clickB = _drop = null;
             }
         }
 
@@ -209,41 +269,92 @@ namespace Roulette.Wpf.Views
         {
             var sri = Application.GetResourceStream(new Uri(packUri));
             if (sri == null) throw new FileNotFoundException(packUri);
-            using var s = sri.Stream;
-            var ms = new MemoryStream();
-            s.CopyTo(ms);
-            ms.Position = 0;
-            return new SoundPlayer(ms);
+            using var stream = sri.Stream;
+            var memory = new MemoryStream();
+            stream.CopyTo(memory);
+            memory.Position = 0;
+            return new SoundPlayer(memory);
         }
-        private void PlayClick() => System.Media.SystemSounds.Asterisk.Play();
-        private void PlayDrop() => System.Media.SystemSounds.Exclamation.Play();
 
-        //private void PlayClick()
-        //{
-        //    var p = (_useA ? _clickA : _clickB);
-        //    _useA = !_useA;
-        //    try { p?.Play(); } catch { /* ignore */ }
-        //}
+        private void PlayClick()
+        {
+            var player = _useA ? _clickA : _clickB;
+            _useA = !_useA;
+            try { player?.Play(); }
+            catch { SystemSounds.Asterisk.Play(); }
+        }
 
-        //private void PlayDrop()
-        //{
-        //    try { _drop?.Play(); } catch { /* ignore */ }
-        //}
+        private void PlayDrop()
+        {
+            try { (_drop ?? SystemSounds.Exclamation).Play(); }
+            catch { SystemSounds.Exclamation.Play(); }
+        }
 
-        // ----- helpers -----
-        private static double Mod(double x, double m) => (x % m + m) % m;
+        // ----- Helpers -----
+        private static double Mod(double value, double modulus) => (value % modulus + modulus) % modulus;
+        private static double NormalizeDegrees(double value)
+        {
+            value %= 360.0;
+            if (value < 0) value += 360.0;
+            return value;
+        }
         private static double Lerp(double a, double b, double t) => a + (b - a) * t;
 
-        // Easing functions (0..1 -> 0..1)
         private static double EaseOutQuint(double x)
         {
             x = Math.Clamp(x, 0, 1);
             return 1 - Math.Pow(1 - x, 5);
         }
+
         private static double EaseOutCubic(double x)
         {
             x = Math.Clamp(x, 0, 1);
             return 1 - Math.Pow(1 - x, 3);
+        }
+
+        private static double EaseInOutQuint(double x)
+        {
+            x = Math.Clamp(x, 0, 1);
+            return x < 0.5
+                ? 16 * Math.Pow(x, 5)
+                : 1 - Math.Pow(-2 * x + 2, 5) / 2;
+        }
+
+        private readonly struct SpinAnimationPlan
+        {
+            public SpinAnimationPlan(double wheelStart, double wheelEnd, double relativeStart, double relativeEnd, double durationSeconds)
+            {
+                WheelStartAngle = wheelStart;
+                WheelEndAngle = wheelEnd;
+                BallRelativeStartAngle = relativeStart;
+                BallRelativeEndAngle = relativeEnd;
+                DurationSeconds = durationSeconds;
+            }
+
+            public double WheelStartAngle { get; }
+            public double WheelEndAngle { get; }
+            public double BallRelativeStartAngle { get; }
+            public double BallRelativeEndAngle { get; }
+            public double DurationSeconds { get; }
+        }
+
+        public sealed class WheelLabel
+        {
+            public WheelLabel(int number, double left, double top, double angle, Brush background)
+            {
+                Number = number;
+                Left = left;
+                Top = top;
+                Angle = angle;
+                Background = background;
+            }
+
+            public int Number { get; }
+            public double Left { get; }
+            public double Top { get; }
+            public double Angle { get; }
+            public double TextAngle => -Angle;
+            public Brush Background { get; }
         }
     }
 }


### PR DESCRIPTION
## Summary
- overlay numbered pockets around the wheel using generated layout data
- expose wheel label metadata so the XAML can stamp colors and angles that match the European wheel order
- confine the animated ball to the wheel interior with a clipped orbit container and refreshed transforms

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd92ccb3cc8323a3c391094a93b838