### PR TITLE
Replace roulette wheel with animated vector control

### DIFF
--- a/Roulette.wpf/Views/Controls/RouletteWheelControl.xaml
+++ b/Roulette.wpf/Views/Controls/RouletteWheelControl.xaml
@@ -1,0 +1,42 @@
+<UserControl x:Class="Roulette.Wpf.Views.Controls.RouletteWheelControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignWidth="700"
+             d:DesignHeight="700">
+    <Grid Background="#111">
+        <Viewbox Stretch="Uniform">
+            <Grid Width="700" Height="700">
+                <Ellipse Width="700" Height="700" Fill="#0e3a22" Stroke="#083019" StrokeThickness="4"/>
+                <Grid x:Name="WheelRoot" Width="620" Height="620">
+                    <Grid.RenderTransform>
+                        <RotateTransform x:Name="WheelRotate" Angle="0" CenterX="310" CenterY="310"/>
+                    </Grid.RenderTransform>
+
+                    <Ellipse Width="620" Height="620" Fill="#202020" Stroke="#555" StrokeThickness="3"/>
+                    <Canvas x:Name="PocketsLayer" Width="620" Height="620"/>
+                    <Ellipse Width="480" Height="480" Fill="#2a2a2a" Stroke="#444" StrokeThickness="2"/>
+                    <Ellipse Width="330" Height="330" Fill="#1e1e1e" Stroke="#3a3a3a" StrokeThickness="1"/>
+                    <Ellipse Width="125" Height="125" Fill="#2b2b2b" Stroke="#777" StrokeThickness="3"/>
+                    <Ellipse Width="18" Height="18" Fill="#bbb" Stroke="#111" StrokeThickness="1"/>
+                </Grid>
+
+                <Canvas x:Name="BallLayer" Width="700" Height="700" IsHitTestVisible="False">
+                    <Ellipse x:Name="Ball"
+                             Width="14" Height="14"
+                             Fill="White" Stroke="#999" StrokeThickness="1">
+                        <Ellipse.Effect>
+                            <DropShadowEffect BlurRadius="8" ShadowDepth="0" Color="#77000000"/>
+                        </Ellipse.Effect>
+                    </Ellipse>
+                </Canvas>
+
+                <Grid HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,12,0,0">
+                    <Polygon Points="0,0 14,0 7,12" Fill="White" Stroke="#444" StrokeThickness="1"/>
+                </Grid>
+            </Grid>
+        </Viewbox>
+    </Grid>
+</UserControl>

--- a/Roulette.wpf/Views/Controls/RouletteWheelControl.xaml.cs
+++ b/Roulette.wpf/Views/Controls/RouletteWheelControl.xaml.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using System.Windows.Threading;
+
+namespace Roulette.Wpf.Views.Controls;
+
+public partial class RouletteWheelControl : UserControl
+{
+    private static readonly int[] EuropeanOrder =
+    {
+        0, 32, 15, 19, 4, 21, 2, 25, 17, 34, 6, 27, 13, 36, 11, 30, 8, 23,
+        10, 5, 24, 16, 33, 1, 20, 14, 31, 9, 22, 18, 29, 7, 28, 12, 35, 3, 26
+    };
+
+    private readonly double _slotAngle = 360.0 / 37.0;
+    private readonly DispatcherTimer _timer = new() { Interval = TimeSpan.FromMilliseconds(16) };
+
+    private double _wheelAngle;
+    private double _wheelVel;
+    private double _ballAngle;
+    private double _ballVel;
+    private double _ballRadius;
+    private double _ballRadVel;
+    private bool _captured;
+    private bool _spinning;
+
+    private int _targetNumber;
+    private int _targetIndex;
+    private double _targetPocketAngle;
+
+    private const double CanvasSize = 700.0;
+    private const double WheelSize = 620.0;
+    private readonly Point _center = new(CanvasSize / 2.0, CanvasSize / 2.0);
+
+    private const double BallOuterRadius = 300;
+    private const double PocketCenterRadius = 240;
+    private const double PocketInnerRadius = 210;
+
+    public RouletteWheelControl()
+    {
+        InitializeComponent();
+        BuildPockets();
+        PlaceBallAt(_center.X, _center.Y - BallOuterRadius);
+        _timer.Tick += OnTick;
+    }
+
+    public bool IsSpinning => _spinning;
+
+    public event EventHandler? SpinCompleted;
+
+    public void Reset()
+    {
+        _timer.Stop();
+        _spinning = false;
+        _captured = false;
+        _wheelVel = 0;
+        _ballVel = 0;
+        _ballRadVel = 0;
+        _ballRadius = BallOuterRadius;
+        MoveBall(_ballAngle, _ballRadius);
+    }
+
+    public void SpinToNumber(int number)
+    {
+        if (_spinning)
+            return;
+
+        _spinning = true;
+        _captured = false;
+
+        _targetNumber = number;
+        _targetIndex = Array.IndexOf(EuropeanOrder, _targetNumber);
+        if (_targetIndex < 0) _targetIndex = 0;
+        _targetPocketAngle = PocketAngleForIndex(_targetIndex);
+
+        _wheelAngle = NormalizeDeg(_wheelAngle);
+        _wheelVel = 650;
+        _ballAngle = _wheelAngle - 90 + 180;
+        _ballVel = 1400;
+        _ballRadius = BallOuterRadius;
+        _ballRadVel = 0;
+
+        _timer.Start();
+    }
+
+    private void OnTick(object? sender, EventArgs e)
+    {
+        double dt = _timer.Interval.TotalSeconds;
+
+        const double wheelFric = 180;
+        const double ballFric = 280;
+
+        _wheelVel = ApproachZero(_wheelVel, wheelFric * dt);
+        _ballVel = ApproachZero(_ballVel, ballFric * dt);
+
+        _wheelAngle += _wheelVel * dt;
+        _ballAngle += _ballVel * dt;
+
+        if (Math.Abs(_ballVel) < 520 && _ballRadius > PocketCenterRadius + 6 && !_captured)
+        {
+            _ballRadVel = -60;
+        }
+
+        _ballRadius += _ballRadVel * dt;
+        if (_ballRadius < PocketCenterRadius) _ballRadius = PocketCenterRadius;
+
+        if (!_captured && Math.Abs(_ballVel) < 120 && Math.Abs(_wheelVel) < 160 && _ballRadius <= PocketCenterRadius + 1)
+        {
+            double targetGlobal = NormalizeDeg(_wheelAngle + _targetPocketAngle);
+            double diff = ShortestDeltaDeg(_ballAngle, targetGlobal);
+            if (Math.Abs(diff) < 7.0)
+            {
+                _captured = true;
+                _ballAngle = targetGlobal;
+                _ballVel = 0;
+                _ballRadVel = -80;
+            }
+            else
+            {
+                double nudge = Clamp(diff, -80 * dt, 80 * dt);
+                _ballAngle = NormalizeDeg(_ballAngle + nudge);
+            }
+        }
+
+        if (_captured && _ballRadius > PocketInnerRadius + 6)
+        {
+            _ballRadVel = -120;
+        }
+        if (_captured && _ballRadius <= PocketInnerRadius + 6)
+        {
+            _ballRadVel = 0;
+            _ballRadius = PocketInnerRadius + 6;
+        }
+
+        if (_captured && Math.Abs(_wheelVel) < 8 && Math.Abs(_ballRadVel) < 5)
+        {
+            _timer.Stop();
+            _spinning = false;
+            SpinCompleted?.Invoke(this, EventArgs.Empty);
+        }
+
+        WheelRotate.Angle = _wheelAngle;
+        MoveBall(_ballAngle, _ballRadius);
+    }
+
+    private void BuildPockets()
+    {
+        PocketsLayer.Children.Clear();
+
+        double cx = WheelSize / 2.0;
+        double cy = WheelSize / 2.0;
+
+        for (int i = 0; i < EuropeanOrder.Length; i++)
+        {
+            int num = EuropeanOrder[i];
+            string col = PocketBrushKey(num);
+
+            var slice = CreateSlice(cx, cy, PocketInnerRadius, PocketCenterRadius + 32, i * _slotAngle - 90, (i + 1) * _slotAngle - 90);
+            slice.Fill = FindResourceOrDefault(col, new SolidColorBrush(ColorFromHex("#d32f2f")));
+            slice.Stroke = Brushes.Black;
+            slice.StrokeThickness = 1;
+            PocketsLayer.Children.Add(slice);
+
+            double midAngle = (i + 0.5) * _slotAngle - 90;
+            var (tx, ty) = Polar(cx, cy, PocketCenterRadius + 10, midAngle);
+            var tb = new TextBlock
+            {
+                Text = num.ToString(),
+                Foreground = Brushes.White,
+                FontWeight = FontWeights.SemiBold,
+                FontSize = 14,
+                RenderTransform = new RotateTransform(midAngle + 90, 0, 0)
+            };
+            Canvas.SetLeft(tb, tx - 8);
+            Canvas.SetTop(tb, ty - 9);
+            PocketsLayer.Children.Add(tb);
+        }
+
+        var ring = new Ellipse
+        {
+            Width = PocketCenterRadius * 2 + 4,
+            Height = PocketCenterRadius * 2 + 4,
+            Stroke = Brushes.White,
+            StrokeThickness = 1.5
+        };
+        Canvas.SetLeft(ring, (WheelSize - ring.Width) / 2);
+        Canvas.SetTop(ring, (WheelSize - ring.Height) / 2);
+        PocketsLayer.Children.Add(ring);
+    }
+
+    private static Path CreateSlice(double cx, double cy, double rInner, double rOuter, double startDeg, double endDeg)
+    {
+        double s = Deg2Rad(startDeg);
+        double e = Deg2Rad(endDeg);
+        Point p1 = new(cx + rOuter * Math.Cos(s), cy + rOuter * Math.Sin(s));
+        Point p2 = new(cx + rOuter * Math.Cos(e), cy + rOuter * Math.Sin(e));
+        Point p3 = new(cx + rInner * Math.Cos(e), cy + rInner * Math.Sin(e));
+        Point p4 = new(cx + rInner * Math.Cos(s), cy + rInner * Math.Sin(s));
+
+        bool largeArc = (endDeg - startDeg) > 180;
+
+        var fig = new PathFigure { StartPoint = p1, IsClosed = true, IsFilled = true };
+        fig.Segments.Add(new ArcSegment(p2, new Size(rOuter, rOuter), 0, largeArc, SweepDirection.Clockwise, true));
+        fig.Segments.Add(new LineSegment(p3, true));
+        fig.Segments.Add(new ArcSegment(p4, new Size(rInner, rInner), 0, largeArc, SweepDirection.Counterclockwise, true));
+
+        return new Path { Data = new PathGeometry { Figures = { fig } } };
+    }
+
+    private static (double x, double y) Polar(double cx, double cy, double r, double deg)
+    {
+        double rad = Deg2Rad(deg);
+        return (cx + r * Math.Cos(rad), cy + r * Math.Sin(rad));
+    }
+
+    private void MoveBall(double angleDeg, double radius)
+    {
+        var (x, y) = Polar(_center.X, _center.Y, radius, angleDeg);
+        Canvas.SetLeft(Ball, x - Ball.Width / 2.0);
+        Canvas.SetTop(Ball, y - Ball.Height / 2.0);
+    }
+
+    private void PlaceBallAt(double x, double y)
+    {
+        Canvas.SetLeft(Ball, x - Ball.Width / 2.0);
+        Canvas.SetTop(Ball, y - Ball.Height / 2.0);
+    }
+
+    private double PocketAngleForIndex(int index) => index * _slotAngle - 90.0;
+
+    private static double Deg2Rad(double d) => d * Math.PI / 180.0;
+
+    private static double NormalizeDeg(double d)
+    {
+        d %= 360.0;
+        if (d < 0) d += 360.0;
+        return d;
+    }
+
+    private static double ShortestDeltaDeg(double a, double b)
+    {
+        double d = NormalizeDeg(b) - NormalizeDeg(a);
+        if (d > 180) d -= 360;
+        if (d < -180) d += 360;
+        return d;
+    }
+
+    private static double Clamp(double v, double min, double max) => Math.Min(Math.Max(v, min), max);
+
+    private static double ApproachZero(double v, double step)
+    {
+        if (v > 0)
+        {
+            v -= step;
+            if (v < 0) v = 0;
+        }
+        else if (v < 0)
+        {
+            v += step;
+            if (v > 0) v = 0;
+        }
+        return v;
+    }
+
+    private static string PocketBrushKey(int number)
+    {
+        if (number == 0) return "RouletteGreen";
+        int[] reds = { 1, 3, 5, 7, 9, 12, 14, 16, 18, 19, 21, 23, 25, 27, 30, 32, 34, 36 };
+        return reds.Contains(number) ? "RouletteRed" : "RouletteBlack";
+    }
+
+    private Brush FindResourceOrDefault(string key, Brush fallback)
+    {
+        if (TryFindResource(key) is Brush brush)
+        {
+            return brush;
+        }
+
+        return key switch
+        {
+            "RouletteRed" => new SolidColorBrush(ColorFromHex("#c62828")),
+            "RouletteBlack" => new SolidColorBrush(ColorFromHex("#111111")),
+            "RouletteGreen" => new SolidColorBrush(ColorFromHex("#0f9d58")),
+            _ => fallback
+        };
+    }
+
+    private static Color ColorFromHex(string hex) => (Color)ColorConverter.ConvertFromString(hex);
+}

--- a/Roulette.wpf/Views/RouletteWindow.xaml
+++ b/Roulette.wpf/Views/RouletteWindow.xaml
@@ -4,6 +4,7 @@
     xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
     xmlns:viewModels="clr-namespace:Roulette.Wpf.ViewModels"
     xmlns:conv="clr-namespace:Roulette.Wpf.Converters"
+    xmlns:controlsLocal="clr-namespace:Roulette.Wpf.Views.Controls"
     Title="Roulette" Width="1180" Height="820" WindowStartupLocation="CenterScreen">
 
     <!-- ViewModel -->
@@ -20,6 +21,9 @@
         <SolidColorBrush x:Key="NumRed" Color="#b12c2c"/>
         <SolidColorBrush x:Key="NumBlack" Color="#222222"/>
         <SolidColorBrush x:Key="NumGreen" Color="#0e7a3a"/>
+        <SolidColorBrush x:Key="RouletteRed" Color="#c62828"/>
+        <SolidColorBrush x:Key="RouletteBlack" Color="#111111"/>
+        <SolidColorBrush x:Key="RouletteGreen" Color="#0f9d58"/>
 
         <!-- Converters -->
         <conv:SpinColorToBrushConverter x:Key="SpinColorToBrushConverter"/>
@@ -260,44 +264,7 @@
 
             <!-- ===== RIGHT: WHEEL (animated) ===== -->
             <Border Style="{StaticResource Card}">
-                <Grid>
-                    <!-- Wheel image with a named RotateTransform we animate -->
-                    <Grid>
-                        <Image
-                         Source="/Roulette.Wpf;component/Assets/wheel.png"
-                         Stretch="Uniform"
-                         RenderOptions.BitmapScalingMode="HighQuality"
-                         HorizontalAlignment="Center"
-                         VerticalAlignment="Center"
-                         Width="360" Height="360">
-                            <Image.RenderTransform>
-                                <RotateTransform x:Name="WheelRotate" Angle="0" CenterX="180" CenterY="180"/>
-                            </Image.RenderTransform>
-                        </Image>
-
-                        <!-- Ball orbiting the wheel (perfect circle around the center) -->
-                        <Ellipse x:Name="Ball"
-         Width="12" Height="12"
-         Fill="White" Stroke="#999" StrokeThickness="1"
-         HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,22,0,0">
-                            <Ellipse.Effect>
-                                <DropShadowEffect BlurRadius="6" ShadowDepth="0" Color="#66000000"/>
-                            </Ellipse.Effect>
-                            <Ellipse.RenderTransform>
-                                <!-- CenterX/CenterY must match half the wheel size (180 for 360px wheel) -->
-                                <RotateTransform x:Name="BallRotate" Angle="0" CenterX="180" CenterY="180"/>
-                            </Ellipse.RenderTransform>
-                        </Ellipse>
-
-                        <!-- Fixed marker at the top (ball “window”) -->
-                        <Grid HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,6,0,0">
-                            <Polygon Points="0,0 12,0 6,10" Fill="White" Stroke="#444" StrokeThickness="1"/>
-                        </Grid>
-
-                        <!-- Subtle inner shading -->
-                        <Ellipse Width="360" Height="360" Stroke="#22000000" StrokeThickness="8" />
-                    </Grid>
-                </Grid>
+                <controlsLocal:RouletteWheelControl x:Name="WheelControl"/>
             </Border>
 
             <!-- ===== Bets summary ===== -->
@@ -344,6 +311,17 @@
                     <StackPanel Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center">
                         <Button Content="Spin" Width="160" Height="44" Command="{Binding SpinCommand}"/>
                         <Button Content="Clear Bets" Width="160" Margin="0,8,0,0" Command="{Binding ClearBetsCommand}"/>
+                        <StackPanel Orientation="Horizontal" Margin="0,12,0,0" VerticalAlignment="Center">
+                            <CheckBox Content="Use seed"
+                                      IsChecked="{Binding UseSeed}"
+                                      VerticalAlignment="Center"
+                                      Margin="0,0,8,0"/>
+                            <TextBox Width="100"
+                                     Height="26"
+                                     VerticalContentAlignment="Center"
+                                     IsEnabled="{Binding UseSeed}"
+                                     Text="{Binding SeedText, UpdateSourceTrigger=PropertyChanged}"/>
+                        </StackPanel>
                     </StackPanel>
                 </Grid>
             </Border>

--- a/Roulette.wpf/Views/RouletteWindow.xaml.cs
+++ b/Roulette.wpf/Views/RouletteWindow.xaml.cs
@@ -1,249 +1,46 @@
-﻿using MahApps.Metro.Controls;
+using MahApps.Metro.Controls;
 using System;
-using System.IO;
-using System.Media;
 using System.Windows;
-using System.Windows.Media;
-using System.Windows.Media.Animation;
-using System.Windows.Threading;
 
-namespace Roulette.Wpf.Views
+namespace Roulette.Wpf.Views;
+
+public partial class RouletteWindow : MetroWindow
 {
-    public partial class RouletteWindow : MetroWindow
+    private ViewModels.GameViewModel? _vm;
+
+    public RouletteWindow()
     {
-        // ----- Wheel / ball parameters -----
-        private const double SPIN_SECONDS = 8.0;      // total spin time
-        private const int WHEEL_REVS = 9;        // visual full turns (clockwise)
-        private const int BALL_REVS = 6;        // visual full turns CCW before settling
-        private const double SECTOR_DEGREES = 360.0 / 37.0;
-        private const double OFFSET_DEGREES = 0.0;      // nudge if your PNG's "0" isn't at the marker
+        InitializeComponent();
 
-        // European wheel order, clockwise from 0
-        private static readonly int[] WheelOrder =
-        {
-            0,32,15,19,4,21,2,25,17,34,6,27,13,36,11,30,8,23,
-            10,5,24,16,33,1,20,14,31,9,22,18,29,7,28,12,35,3,26
-        };
+        WheelControl.SpinCompleted += WheelControlOnSpinCompleted;
 
-        // state
-        private double _startAngle;   // wheel angle at spin start
-        private double _endAngle;     // wheel angle at spin end
-        private double _currentAngle; // wheel angle we keep after spin
-        private DateTime _spinStart;
-        private bool _spinning;
+        HookViewModel();
+        DataContextChanged += (_, __) => HookViewModel();
+        Unloaded += (_, __) => UnhookViewModel();
+    }
 
-        // VM + sounds
-        private ViewModels.GameViewModel? _vm;
-        private SoundPlayer? _clickA, _clickB, _drop;
-        private bool _useA = true;
-        private DispatcherTimer? _tickTimer;
+    private void WheelControlOnSpinCompleted(object? sender, EventArgs e)
+    {
+        _vm?.CommitPendingSpin();
+    }
 
-        public RouletteWindow()
-        {
-            InitializeComponent();
+    private void HookViewModel()
+    {
+        UnhookViewModel();
+        _vm = DataContext as ViewModels.GameViewModel;
+        if (_vm is null) return;
+        _vm.SpinRequested += OnSpinRequested;
+    }
 
-            HookViewModel();
-            DataContextChanged += (_, __) => HookViewModel();
-            Unloaded += (_, __) => UnhookViewModel();
+    private void UnhookViewModel()
+    {
+        if (_vm is null) return;
+        _vm.SpinRequested -= OnSpinRequested;
+        _vm = null;
+    }
 
-            TryLoadSounds();
-        }
-
-        private void HookViewModel()
-        {
-            UnhookViewModel();
-            _vm = DataContext as ViewModels.GameViewModel;
-            if (_vm is null) return;
-            _vm.SpinRequested += AnimateToNumber;
-        }
-
-        private void UnhookViewModel()
-        {
-            if (_vm is null) return;
-            _vm.SpinRequested -= AnimateToNumber;
-            _vm = null;
-        }
-
-        // ----- Spin orchestration (render loop) -----
-        private void AnimateToNumber(int number)
-        {
-            // compute target wheel angle so 'number' lands under the top marker
-            int idx = Array.IndexOf(WheelOrder, number);
-            if (idx < 0) idx = 0;
-
-            double targetAngleAtMarker = OFFSET_DEGREES + idx * SECTOR_DEGREES;
-
-            // align from our current angle to that target with several full clockwise turns
-            _startAngle = _currentAngle;
-            // how far clockwise from currentMod to target in [0,360)
-            double currentMod = Mod(_startAngle, 360.0);
-            double delta = targetAngleAtMarker - currentMod;
-            if (delta < 0) delta += 360.0;
-
-            _endAngle = _startAngle + WHEEL_REVS * 360.0 + delta;
-
-            // start timing
-            _spinStart = DateTime.UtcNow;
-            _spinning = true;
-
-            // start SFX ticking
-            StartTickTimer();
-
-            // drive both wheel and ball with the same render tick
-            CompositionTarget.Rendering -= OnRenderSpin;
-            CompositionTarget.Rendering += OnRenderSpin;
-        }
-
-        private void OnRenderSpin(object? sender, EventArgs e)
-        {
-            if (!_spinning) return;
-
-            double t = (DateTime.UtcNow - _spinStart).TotalSeconds;
-            double p = Math.Clamp(t / SPIN_SECONDS, 0.0, 1.0);
-
-            // Easing for the wheel (quintic ease out)
-            double ew = EaseOutQuint(p);
-            double wheelAngle = Lerp(_startAngle, _endAngle, ew);
-            WheelRotate.Angle = wheelAngle;
-
-            // Ball angle: start with BALL_REVS CCW turns, decelerate and land at marker (angle 0)
-            // Use a slightly different curve so the ball feels lighter (cubic ease out towards ~6s, then in)
-            // We'll combine two phases via one smooth curve: fast at start, gently to 0.
-            double eb = EaseOutCubic(p);            // decelerate early
-            double ballTurns = (1.0 - eb) * BALL_REVS;   // remaining turns to go
-            double ballAngle = -ballTurns * 360.0;       // negative = CCW from the top marker
-            BallRotate.Angle = ballAngle;
-
-            // end of spin
-            if (p >= 1.0)
-            {
-                _spinning = false;
-                CompositionTarget.Rendering -= OnRenderSpin;
-
-                // lock final angles
-                _currentAngle = _endAngle;
-                WheelRotate.Angle = _currentAngle;
-                BallRotate.Angle = 0; // ball at the marker
-
-                StopTickTimer();
-                PlayDrop();
-                BallBounce();
-
-                // commit logical spin result/payout
-                _vm?.CommitPendingSpin();
-            }
-        }
-
-        // Small visual bounce on "drop"
-        private void BallBounce()
-        {
-            // A tiny scale/translate using a transient animation (doesn't affect the circular path during spin)
-            // We momentarily nudge the Ball element down and back up by adjusting Margin.Top.
-            var start = Ball.Margin;
-            var down = new Thickness(start.Left, start.Top + 3, start.Right, start.Bottom);
-
-            var a = new System.Windows.Media.Animation.ThicknessAnimation
-            {
-                From = start,
-                To = down,
-                Duration = TimeSpan.FromMilliseconds(100),
-                AutoReverse = true,
-                EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut }
-            };
-            Ball.BeginAnimation(MarginProperty, a);
-        }
-
-        // ----- Sounds -----
-        private void StartTickTimer()
-        {
-            _tickTimer?.Stop();
-            _tickTimer = new DispatcherTimer(DispatcherPriority.Background)
-            {
-                Interval = TimeSpan.FromMilliseconds(85) // fast at start
-            };
-            _tickTimer.Tick += TickTimerOnTick;
-            _tickTimer.Start();
-        }
-
-        private void StopTickTimer()
-        {
-            if (_tickTimer == null) return;
-            _tickTimer.Stop();
-            _tickTimer.Tick -= TickTimerOnTick;
-            _tickTimer = null;
-        }
-
-        private void TickTimerOnTick(object? sender, EventArgs e)
-        {
-            // slow the ticking as we approach the end
-            var elapsed = (DateTime.UtcNow - _spinStart).TotalSeconds;
-            double p = Math.Clamp(elapsed / SPIN_SECONDS, 0.0, 1.0);
-
-            // ease interval from ~85ms to ~220ms
-            double ms = 85 + 135 * p;
-            if (_tickTimer != null) _tickTimer.Interval = TimeSpan.FromMilliseconds(ms);
-
-            PlayClick();
-
-            if (p >= 1.0) StopTickTimer();
-        }
-
-        private void TryLoadSounds()
-        {
-            // Optional WAVs (Build Action: Resource):
-            //  /Roulette.Wpf;component/Assets/Sounds/click.wav
-            //  /Roulette.Wpf;component/Assets/Sounds/drop.wav
-            try
-            {
-                _clickA = LoadWav("pack://application:,,,/Roulette.Wpf;component/Assets/Sounds/click.wav");
-                _clickB = LoadWav("pack://application:,,,/Roulette.Wpf;component/Assets/Sounds/click.wav");
-                _drop = LoadWav("pack://application:,,,/Roulette.Wpf;component/Assets/Sounds/drop.wav");
-            }
-            catch
-            {
-                _clickA = _clickB = _drop = null; // run silent if missing
-            }
-        }
-
-        private static SoundPlayer LoadWav(string packUri)
-        {
-            var sri = Application.GetResourceStream(new Uri(packUri));
-            if (sri == null) throw new FileNotFoundException(packUri);
-            using var s = sri.Stream;
-            var ms = new MemoryStream();
-            s.CopyTo(ms);
-            ms.Position = 0;
-            return new SoundPlayer(ms);
-        }
-        private void PlayClick() => System.Media.SystemSounds.Asterisk.Play();
-        private void PlayDrop() => System.Media.SystemSounds.Exclamation.Play();
-
-        //private void PlayClick()
-        //{
-        //    var p = (_useA ? _clickA : _clickB);
-        //    _useA = !_useA;
-        //    try { p?.Play(); } catch { /* ignore */ }
-        //}
-
-        //private void PlayDrop()
-        //{
-        //    try { _drop?.Play(); } catch { /* ignore */ }
-        //}
-
-        // ----- helpers -----
-        private static double Mod(double x, double m) => (x % m + m) % m;
-        private static double Lerp(double a, double b, double t) => a + (b - a) * t;
-
-        // Easing functions (0..1 -> 0..1)
-        private static double EaseOutQuint(double x)
-        {
-            x = Math.Clamp(x, 0, 1);
-            return 1 - Math.Pow(1 - x, 5);
-        }
-        private static double EaseOutCubic(double x)
-        {
-            x = Math.Clamp(x, 0, 1);
-            return 1 - Math.Pow(1 - x, 3);
-        }
+    private void OnSpinRequested(int number)
+    {
+        Dispatcher.Invoke(() => WheelControl.SpinToNumber(number));
     }
 }


### PR DESCRIPTION
## Summary
- add a vector-based roulette wheel control with animated ball physics
- integrate the control into the roulette window and surface deterministic seeding UI
- update the game view model to manage seeded spins and prevent overlapping animations

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd98da75fc8323a235360eb818cf72